### PR TITLE
Instagram stories

### DIFF
--- a/_captures/instagram-story.md
+++ b/_captures/instagram-story.md
@@ -8,8 +8,8 @@ es:
   title: Enlaces en historias de Instagram
   description: Permite a tus fans suscribirse fácilmente a tu negocio directamente desde una historia de Instagram.
 
-permalink: instagram-story-link
-permalink_es: enlaces-en-historias-de-instagram
+permalink: captures/instagram-story
+permalink_es: captures/historias-de-instagram
 
 layout: guide
 topic: captures

--- a/_i18n/en/captures/instagram-story.md
+++ b/_i18n/en/captures/instagram-story.md
@@ -54,5 +54,5 @@ To add a Link sticker
 1. Capture or upload content to your story
 2. Select the **Sticker** tool. This may be placed differently depending on which version of Instagram you're using.
 3. Tap the “Link” sticker, here you should paste the shareable link for the created Instagram Story
-4. Place the sticker on your story, do any other modifications needed.
+4. Place the sticker on your story, do any other modifications needed
 5. Publish your story

--- a/_i18n/en/captures/instagram-story.md
+++ b/_i18n/en/captures/instagram-story.md
@@ -52,7 +52,7 @@ Use the Link sticker to add a link to your Instagram story. When people tap on t
 To add a Link sticker
 
 1. Capture or upload content to your story
-2. Select the sticker tool from the top navigation bar
+2. Select the **Sticker** tool. This may be placed differently depending on which version of Instagram you're using.
 3. Tap the “Link” sticker, here you should paste the shareable link for the created Instagram Story
 4. Place the sticker on your story, do any other modifications needed.
 5. Publish your story

--- a/_i18n/en/captures/instagram-story.md
+++ b/_i18n/en/captures/instagram-story.md
@@ -1,6 +1,9 @@
-By using Instagram's Story capture tools, you can create a special SMS protocol link that allows users to subscribe directly to your business without ever leaving Instagram. 
+By using Instagram's Story capture tools, you can create a special SMS or WhatsApp protocol link that allows users to subscribe directly to your business, the clicked link will open the default Messages or WhatsApp app on 
+your customers' phones, allowing them a one-tap subscription method. Then you can know who and what rate of your subscribers are 
+from Instagram.
 
-When users click the link, their SMS app will open with a pre-filled opt-in message and phone number. All they have to do is tap *Send* and they'll be subscribed to your business. 
+When users click the link, depending on the configuration you made when creating the capture, either their SMS app or WhatsApp will open with a pre-filled opt-in message and phone number. 
+All they have to do is tap *Send* and they'll be subscribed to your business. 
 
 Plus, you can use Instagram stories to offer incentives for joining, such as coupons, discounts on future purchases, and access to exclusive products.
 
@@ -8,11 +11,19 @@ Plus, you can use Instagram stories to offer incentives for joining, such as cou
 
 To set up an Instagram Story capture link, go to the *Captures* section and click on *New capture method*. Then, select *Instagram Story*. 
 
-If you have phone numbers or short codes associated with your business, you can choose one of these as the number that customers will send the opt-in message to. 
+### Choose the app you want the link to open
+Choose the app you want the link to open once clicked. Available options are _SMS_ or _WhatsApp_. WhatsApp would only be available if you have integrated a WhatsApp account. And go to the next step.
+
+### Choose the phone number and message 
+
+You can choose the phone number that the message would send to,
+
+- If you have selected SMS in the first step, and if you have phone numbers or short codes associated with your business, you can choose one of these as the number that customers will send the opt-in message to.
+- If you have selected WhatsApp, SMS channels you own won't be shown, only integrated WhatsApp phone numbers to your connected WhatsApp Business Account(WABA).
 
 If you don't have a preference or don't have any numbers associated with your business, you can use the default settings and Hellotext will choose the most appropriate number for you. 
 
-You can also customize the pre-filled message that customers will send to subscribe.
+You can also customize the pre-filled message that customers will send to subscribe, you are free to adjust the message to your liking.
 
 ### Assigning coupons and journeys
 
@@ -33,3 +44,15 @@ Move to the last step and copy the link given.
 Share this link on your new Instagram story as you would do with a regular link.
 
 Your customers will be able now to subscribe directly from your Instagram story.
+
+### Share on Instagram {#howto-share-instagram}
+
+Use the Link sticker to add a link to your Instagram story. When people tap on the sticker, they’ll be redirected.
+
+To add a Link sticker
+
+1. Capture or upload content to your story
+2. Select the sticker tool from the top navigation bar
+3. Tap the “Link” sticker, here you should paste the shareable link for the created Instagram Story
+4. Place the sticker on your story, do any other modifications needed.
+5. Publish your story

--- a/_i18n/es/captures/instagram-story.md
+++ b/_i18n/es/captures/instagram-story.md
@@ -1,6 +1,9 @@
-Con los herramientas de captura de historias de Instagram, puedes crear un enlace de protocolo SMS especial que permite a los usuarios suscribirse directamente a tu negocio sin salir de Instagram. 
+Al utilizar las herramientas de captura de Historias de Instagram, puedes crear un enlace especial de protocolo SMS o WhatsApp 
+que permite a los usuarios suscribirse directamente a tu negocio. 
+El enlace, al ser clicado, abrirá la aplicación de Mensajes o WhatsApp predeterminada en los teléfonos de tus clientes, permitiéndoles suscribirse con un solo toque. Así, podrás saber quiénes y qué porcentaje de tus suscriptores provienen de Instagram.
 
-Cuando los usuarios hagan clic en el enlace, su aplicación SMS se abrirá con un mensaje de opt-in y un número de teléfono ya rellenados. 
+Cuando los usuarios hagan clic en el enlace, dependiendo de la configuración que hiciste al crear la captura, 
+se abrirá su aplicación de SMS o WhatsApp con un mensaje de suscripción predefinido y el número de teléfono. Todo lo que tienen que hacer es tocar *Enviar* y estarán suscritos a tu negocio.
 
 Solo tienen que pulsar *Enviar* y estarán suscritos a tu negocio. 
 
@@ -10,11 +13,20 @@ Además, puedes usar las historias de Instagram para ofrecer incentivos para uni
 
 Para crear una captura para compartir en Instagram, desde la sección *Capturas*, haz clic en *Nuevo método de captura*. Luego, selecciona *Enlace para historia de Instagram*.
 
-Si tienes números de teléfono o códigos cortos asociados con su negocio, puedes elegir uno de estos como el número al que los clientes enviarán el mensaje de opt-in.
+### Elige la aplicación que quieres que se abra con el enlace.
 
-Si no tienes preferencias o no tienes números asociados con tu negocio, puedes utilizar la configuración predeterminada y Hellotext elegirá el número más adecuado.
+Elige la aplicación que quieres que se abra al hacer clic en el enlace. Las opciones disponibles son _SMS_ o _WhatsApp_. WhatsApp solo estará disponible si has integrado una cuenta de WhatsApp. Luego, pasa al siguiente paso.
 
-También puedes personalizar el mensaje que los clientes enviarán para suscribirse.
+### Elige el número de teléfono y el mensaje.
+
+Puedes elegir el número de teléfono al que se enviará el mensaje:
+
+- Si seleccionaste SMS en el primer paso, y si tienes números de teléfono o códigos cortos asociados con tu negocio, puedes elegir uno de estos como el número al que los clientes enviarán el mensaje de suscripción.
+- Si seleccionaste WhatsApp, no se mostrarán los canales de SMS que posees, solo los números de teléfono integrados a tu cuenta de WhatsApp Business Account (WABA).
+
+Si no tienes una preferencia o no tienes números asociados con tu negocio, puedes usar la configuración predeterminada y Hellotext elegirá el número más apropiado para ti.
+
+También puedes personalizar el mensaje predefinido que los clientes enviarán para suscribirse, eres libre de ajustar el mensaje a tu gusto.
 
 ## Asignar cupones y rutas
 
@@ -35,3 +47,15 @@ Ve al último paso y copia el enlace proporcionado.
 Comparte este enlace en tu nueva historia de Instagram como lo harías con un enlace regular.
 
 Ahora tus clientes podrán suscribirse directamente desde tu historia de Instagram.
+
+## Compartir en Instagram #{#howto-share-instagram}
+
+Usa la etiqueta de Enlace para añadir un enlace a tu historia de Instagram. Cuando las personas toquen la etiqueta, serán redirigidas.
+
+Para añadir una etiqueta de Enlace:
+
+1. Captura o sube contenido a tu historia.
+2. Selecciona la herramienta de etiquetas desde la barra de navegación superior.
+3. Toca la etiqueta de “Enlace” y pega el enlace compartible para la historia de Instagram creada.
+4. Coloca la etiqueta en tu historia y haz cualquier otra modificación necesaria.
+5. Publica tu historia.

--- a/_i18n/es/captures/instagram-story.md
+++ b/_i18n/es/captures/instagram-story.md
@@ -57,5 +57,5 @@ Para añadir una etiqueta de Enlace:
 1. Captura o sube contenido a tu historia.
 2. Selecciona la herramienta de **Sticker**. Esto puede estar ubicado en diferentes lugares dependiendo de la versión de Instagram que estés utilizando.
 3. Toca la etiqueta de “Enlace” y pega el enlace compartible para la historia de Instagram creada.
-4. Coloca la etiqueta en tu historia y haz cualquier otra modificación necesaria.
+4. Coloca la etiqueta en tu historia y haz cualquier otra modificación necesaria
 5. Publica tu historia.

--- a/_i18n/es/captures/instagram-story.md
+++ b/_i18n/es/captures/instagram-story.md
@@ -55,7 +55,7 @@ Usa la etiqueta de Enlace para añadir un enlace a tu historia de Instagram. Cua
 Para añadir una etiqueta de Enlace:
 
 1. Captura o sube contenido a tu historia.
-2. Selecciona la herramienta de etiquetas desde la barra de navegación superior.
+2. Selecciona la herramienta de **Sticker**. Esto puede estar ubicado en diferentes lugares dependiendo de la versión de Instagram que estés utilizando.
 3. Toca la etiqueta de “Enlace” y pega el enlace compartible para la historia de Instagram creada.
 4. Coloca la etiqueta en tu historia y haz cualquier otra modificación necesaria.
 5. Publica tu historia.


### PR DESCRIPTION
Alongside our work on adjustments to Instagram Story captures. We've updated the guide for them. 

Specifically, we've highlighted the possibility of choosing the technology and what that means for the link when it is opened. Additionally, we've added a new section at the bottom of the page, titled How to share on Instagram because most people don't know how to share links in Instagram stories. 

<img width="703" alt="Screenshot 2024-07-12 at 11 51 27 AM" src="https://github.com/user-attachments/assets/0821cfe3-e1b0-4f69-b0c3-62240044bc9a">

Both guides' permalinks also are changed to be nested inside a `captures/`. resource. I've taken the steps from [Instagram's official blog](https://about.instagram.com/blog/announcements/expanding-sharing-links-in-stories-to-everyone) but modified it to our needs. 