### PR TITLE
Fix apex domain DNS guidance

### DIFF
--- a/_i18n/en/getting-started/setting-up-your-cname-alias.md
+++ b/_i18n/en/getting-started/setting-up-your-cname-alias.md
@@ -42,9 +42,9 @@ For more information about how to create the correct record, see your DNS provid
 
 ## Configuring an apex domain
 
-To set up an apex domain, such as example.com, you must configure a custom domain in your business settings and at least one ALIAS, ANAME, or A record with your DNS provider.
+To set up an apex domain, such as `example.com`, you must configure a custom domain in your business settings and create an ALIAS or ANAME record with your DNS provider.
 
-For example, if instead of using the subdomain `shop.mysite.com` for Short Links, you want to use the apex domain `mysite.com`, you need to create an ALIAS, ANAME, or A record that points `mysite.com` to `hello.link`.
+For example, if instead of using the subdomain `shop.mysite.com` for Short Links, you want to use the apex domain `mysite.com`, you need to create an ALIAS or ANAME record that points `mysite.com` to `hello.link`.
 
 For more information about how to create the correct record, see your DNS provider's documentation.
 

--- a/_i18n/es/getting-started/setting-up-your-cname-alias.md
+++ b/_i18n/es/getting-started/setting-up-your-cname-alias.md
@@ -40,9 +40,9 @@ Para obtener más información sobre cómo crear el registro correcto, consulta 
 
 ## Configurar un dominio apex
 
-Para configurar un dominio ápice, como por ejemplo `example.com`, debes configurar un dominio personalizado en la configuración de tu negocio y al menos un registro ALIAS, ANAME o A con tu proveedor de DNS.
+Para configurar un dominio ápice, como por ejemplo `example.com`, debes configurar un dominio personalizado en la configuración de tu negocio y crear un registro ALIAS o ANAME con tu proveedor de DNS.
 
-Por ejemplo, si en lugar de utilizar el subdominio `shop.mysite.com` para Enlaces Cortos, deseas usar el dominio ápice `mysite.com`, debes crear un registro ALIAS, ANAME o A que apunte `mysite.com` a `hello.link`.
+Por ejemplo, si en lugar de utilizar el subdominio `shop.mysite.com` para Enlaces Cortos, deseas usar el dominio ápice `mysite.com`, debes crear un registro ALIAS o ANAME que apunte `mysite.com` a `hello.link`.
 
 Para obtener más información sobre cómo crear el registro correcto, consulta la documentación de tu proveedor de DNS.
 


### PR DESCRIPTION
## Summary
- Remove the incorrect `A` record guidance for apex short-link domains
- Clarify that apex domains should use `ALIAS` or `ANAME` records instead
- Apply the same correction in the English and Spanish docs

## Testing
- Not run (not requested)