### PR TITLE
Add response times guidance to Team help section

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -85,6 +85,7 @@ collections:
     order:
       - understanding-team-roles.md
       - assigning-conversations.md
+      - understanding-response-times.md
       - transferring-ownership.md
     output: true
   getting-started:

--- a/_i18n/en/team/understanding-response-times.md
+++ b/_i18n/en/team/understanding-response-times.md
@@ -1,0 +1,114 @@
+Response times help your team understand how quickly customers receive replies and which conversations need attention first.
+
+Response rules define the targets Hellotext uses to decide whether a customer wait is on track, at risk, delayed, or overdue.
+
+> Response rules are available on Pro and Enterprise plans.
+
+## What response rules do
+
+A response rule sets two targets:
+
+- First response to new conversations: the maximum time to respond to the first customer message in a new conversation.
+- Subsequent replies: the maximum time to respond after the customer sends a new message in a conversation that is already active.
+
+Hellotext uses these targets to show response health in conversations, teams, teammates, and reports.
+
+## How response timers work
+
+When a customer sends a message that requires attention, Hellotext starts a response timer.
+
+If the conversation has not received a team reply yet, the timer uses the First response to new conversations target. After your team has replied once, future customer messages use the Subsequent replies target.
+
+If a customer sends multiple messages before your team replies, the timer does not restart. Those messages are treated as part of the same customer wait.
+
+When your team sends a customer-facing reply, Hellotext records the response. If the reply happens before the deadline, the conversation stays within the expected response time. If the reply happens after the deadline, the response is still recorded, but the response target is considered missed.
+
+Internal notes, drafts, campaigns, and system-only activity do not count as responses.
+
+## Business hours
+
+Response deadlines use your configured Business hours.
+
+If a customer writes during open hours, the timer starts immediately. If a customer writes while your business is closed, the timer starts when the business opens again.
+
+If a deadline crosses a closed period, the remaining time continues counting when the business opens again.
+
+## Default policy and channel rules
+
+Every business has a Default response policy. This policy applies when there is no more specific rule for the conversation's channel.
+
+On Pro and Enterprise plans, you can create response rules for specific channels such as WhatsApp, SMS, Webchat, Instagram, or Messenger. When a channel-specific rule exists, Hellotext uses that rule for conversations on that channel. Otherwise, it uses the Default response policy.
+
+Changes to a response rule apply to new response timers. Conversations that already have an active timer keep the deadline that was created when the timer started.
+
+## What teammates see in conversations
+
+In the conversation list, Hellotext may show response status pills to help teammates prioritize their work.
+
+The possible response statuses are:
+
+- Response at risk: the conversation is close to missing its response target.
+- Response delayed: the response target has passed and the customer is still waiting.
+- Response overdue: the wait has remained unresolved after missing the expected response time and needs urgent attention.
+
+These indicators help teammates prioritize the conversations that need the fastest action.
+
+## What supervisors see in teams and teammates
+
+In team and teammate views, Hellotext shows response health indicators when the feature is available.
+
+The possible response health statuses are:
+
+- Response on track
+- Response at risk
+- Response delayed
+- Response overdue
+
+For teams, Hellotext considers conversations currently assigned to that team or pending assignment to that team. For teammates, Hellotext considers conversations assigned to each person.
+
+These statuses do not create separate response rules for each team or teammate. Response rules are configured globally or by channel. Team and teammate views show how those rules are performing operationally.
+
+## Reports
+
+In reports, supervisors can review operational pressure by teammate or by team.
+
+The Operational Pressure report shows information such as unanswered conversations, oldest wait, response risk, utilization, concurrency, and burn.
+
+The response risk statuses are:
+
+- Safe
+- At risk
+- Imminent
+
+This helps supervisors detect when a team or teammate is accumulating conversations that could affect response times.
+
+## How to configure response rules
+
+1. Go to Settings.
+2. Open Team.
+3. Select Response times.
+4. Open the Response rules tab.
+5. Edit the Default response policy, or create a channel-specific response rule.
+6. Set First response to new conversations.
+7. Set Subsequent replies.
+8. Save your changes.
+
+To configure when time should count, use the Business hours tab in the same section.
+
+## Plan requirements
+
+Response rules require a Pro or Enterprise plan.
+
+If your business is not on a supported plan, you can open the Response times page, but response rules are not active. You will see an upgrade button instead of the create button.
+
+Without Pro or Enterprise, response health indicators are hidden from conversations, teams, and teammates.
+
+## Best practices
+
+Use the Default response policy as the normal company-wide expectation.
+
+Create channel-specific rules when some channels need faster or slower response times. For example, you may want WhatsApp conversations answered faster than email-like channels.
+
+Keep Business hours accurate so response times reflect when your team is actually available.
+
+Review conversations, teams, teammates, and reports regularly to detect delays before they affect the customer experience.

--- a/_i18n/es/team/understanding-response-times.md
+++ b/_i18n/es/team/understanding-response-times.md
@@ -1,0 +1,114 @@
+Tiempo de respuesta ayuda a tu equipo a entender qué tan rápido reciben respuesta los clientes y qué conversaciones necesitan atención primero.
+
+Las reglas de respuesta definen los tiempos que Hellotext usa para decidir si una espera está al día, en riesgo, demorada o vencida.
+
+> Las reglas de respuesta están disponibles en los planes Pro y Enterprise.
+
+## Qué son las reglas de respuesta
+
+Una regla de respuesta define dos tiempos:
+
+- Primera respuesta a nuevas conversaciones: tiempo máximo para responder el primer mensaje de un cliente en una conversación nueva.
+- Respuestas posteriores: tiempo máximo para responder después de que el cliente envía un nuevo mensaje en una conversación ya activa.
+
+Hellotext usa estos tiempos para mostrar la salud de respuesta en conversaciones, equipos, colaboradores y reportes.
+
+## Cómo funcionan
+
+Cuando un cliente envía un mensaje que requiere atención, Hellotext inicia un temporizador de respuesta.
+
+Si la conversación todavía no tuvo una respuesta del equipo, se usa el tiempo de Primera respuesta a nuevas conversaciones. Después de que el equipo respondió una vez, los siguientes mensajes del cliente usan el tiempo de Respuestas posteriores.
+
+Si el cliente envía varios mensajes antes de recibir respuesta, el temporizador no se reinicia. Esos mensajes se consideran parte de la misma espera del cliente.
+
+Cuando el equipo envía una respuesta visible para el cliente, Hellotext registra la respuesta. Si llega antes del límite, la conversación sigue dentro del tiempo esperado. Si llega después, la respuesta se registra, pero el tiempo de respuesta se considera vencido.
+
+Las notas internas, borradores, campañas y actividad del sistema no cuentan como respuestas.
+
+## Horario comercial
+
+Los tiempos de respuesta respetan el Horario comercial configurado.
+
+Si un cliente escribe durante el horario abierto, el tiempo empieza a contar en ese momento. Si escribe fuera del horario comercial, el tiempo empieza a contar cuando el negocio vuelve a abrir.
+
+Si un límite cruza un período cerrado, el tiempo restante continúa contando cuando el negocio vuelve a abrir.
+
+## Política predeterminada y reglas por canal
+
+Cada negocio tiene una Política de respuesta predeterminada. Esta política se usa cuando no existe una regla específica para el canal de la conversación.
+
+En planes Pro y Enterprise, puedes crear reglas de respuesta por canal, por ejemplo WhatsApp, SMS, Webchat, Instagram o Messenger. Si existe una regla para el canal, Hellotext usa esa regla. Si no, usa la Política de respuesta predeterminada.
+
+Los cambios a una regla de respuesta aplican a nuevos temporizadores. Las conversaciones que ya tenían un temporizador activo conservan el límite que tenían cuando se inició.
+
+## Estados en conversaciones
+
+En la lista de conversaciones, Hellotext puede mostrar indicadores de respuesta para ayudar a priorizar el trabajo.
+
+Los estados son:
+
+- Respuesta en riesgo: la conversación está cerca de vencer su tiempo de respuesta.
+- Respuesta demorada: el tiempo de respuesta ya pasó y el cliente sigue esperando.
+- Respuesta vencida: la espera sigue sin resolverse después de superar el tiempo esperado y necesita atención urgente.
+
+Estos indicadores ayudan al equipo a priorizar las conversaciones que necesitan una respuesta más rápida.
+
+## Estados en Equipo y colaboradores
+
+En las vistas de Equipo y colaboradores, Hellotext muestra indicadores de salud de respuesta cuando la función está disponible.
+
+Los estados son:
+
+- Respuesta al día
+- Respuesta en riesgo
+- Respuesta demorada
+- Respuesta vencida
+
+En Equipo, Hellotext considera las conversaciones asignadas o pendientes de asignación a ese equipo. En colaboradores, considera las conversaciones asignadas a cada persona.
+
+Estos estados no crean reglas separadas por equipo o colaborador. Las reglas se configuran a nivel general o por canal. Las vistas de Equipo y colaboradores muestran cómo se están cumpliendo.
+
+## Reportes
+
+En reportes, los supervisores pueden revisar la presión operativa por colaborador o por equipo.
+
+El reporte de Presión operativa muestra información como conversaciones sin respuesta, mayor espera, riesgo de respuesta, utilización, concurrencia y burn.
+
+Los estados de riesgo son:
+
+- Seguro
+- En riesgo
+- Inminente
+
+Esto ayuda a detectar cuándo un equipo o colaborador está acumulando conversaciones que podrían afectar los tiempos de respuesta.
+
+## Cómo configurar reglas de respuesta
+
+1. Ve a Ajustes.
+2. Abre Equipo.
+3. Entra en Tiempo de respuesta.
+4. Abre la pestaña Reglas de respuesta.
+5. Edita la Política de respuesta predeterminada o crea una regla por canal.
+6. Configura Primera respuesta a nuevas conversaciones.
+7. Configura Respuestas posteriores.
+8. Guarda los cambios.
+
+Para configurar cuándo debe contar el tiempo, usa la pestaña Horario comercial en la misma sección.
+
+## Plan necesario
+
+Para usar reglas de respuesta necesitas un plan Pro o Enterprise.
+
+Si tu negocio no tiene un plan compatible, puedes abrir la página de Tiempo de respuesta, pero las reglas no estarán activas. Verás un botón para actualizar el plan en lugar del botón para crear una regla.
+
+En planes que no incluyen esta función, los indicadores de salud de respuesta no se muestran en conversaciones, equipos ni colaboradores.
+
+## Buenas prácticas
+
+Usa la Política de respuesta predeterminada como expectativa general para todo el negocio.
+
+Crea reglas de respuesta por canal cuando algunos canales necesiten tiempos distintos. Por ejemplo, es posible que quieras responder conversaciones de WhatsApp más rápido que canales similares al email.
+
+Mantén actualizado el Horario comercial para que los tiempos reflejen cuándo tu equipo realmente está disponible.
+
+Revisa conversaciones, equipos, colaboradores y reportes regularmente para detectar demoras antes de que afecten la experiencia del cliente.

--- a/_team/understanding-response-times.md
+++ b/_team/understanding-response-times.md
@@ -1,0 +1,20 @@
+---
+languages: ["en", "es"]
+
+en:
+  title: Response times and response rules
+  description: Learn how response rules help your team track reply targets, prioritize conversations, and review response health.
+
+es:
+  title: Tiempo de respuesta y reglas de respuesta
+  description: Aprende cómo las reglas de respuesta ayudan a tu equipo a medir tiempos, priorizar conversaciones y revisar la salud de respuesta.
+
+permalink: understanding-response-times
+permalink_es: tiempo-de-respuesta-y-reglas-de-respuesta
+
+layout: guide
+topic: team
+popular: false
+---
+
+{% translate_file team/understanding-response-times.md %}


### PR DESCRIPTION
## Summary
- Adds a new Team article for response times and response rules in English and Spanish.
- Covers how response timers work, business hours, default vs channel rules, team and teammate status pills, reports, setup steps, plan requirements, and best practices.
- Inserts the article into the Team collection order so it appears after Assigning conversations.

## Testing
- `JEKYLL_ENV=production bundle exec jekyll build` passed successfully.
- Verified the new English and Spanish pages were generated in the built site.