### PR TITLE
Clarify sales attribution rules for human interactions

### DIFF
--- a/_billing/how-we-attribute-sales.md
+++ b/_billing/how-we-attribute-sales.md
@@ -3,10 +3,10 @@ languages: ["en", "es"]
 
 en:
   title: How we attribute sales
-  description: Learn how we use last‑click attribution, attribution windows and when we exclude sales.
+  description: Learn how we use last‑click attribution, attribution windows, human interactions, and when we exclude sales.
 es:
   title: Cómo atribuimos las ventas
-  description: Descubre cómo usamos atribución last‑click, ventanas de atribución y cuándo excluimos ventas.
+  description: Descubre cómo usamos atribución last‑click, ventanas de atribución, interacciones humanas y cuándo excluimos ventas.
 
 permalink: how-we-attribute-sales
 permalink_es: como-atribuimos-las-ventas

--- a/_i18n/en/billing/how-we-attribute-sales.md
+++ b/_i18n/en/billing/how-we-attribute-sales.md
@@ -23,6 +23,62 @@ With this mechanism you can be sure that only sales that stem from an impact mad
 * **Manually created events**: follow‑up or sales recording actions that you set up manually outside of Hellotext.
 * **Unconfirmed, canceled, or returned orders**: we attribute only confirmed orders and exclude returns.
 
+## What Happens When Your Team Joins the Conversation?
+
+A sale is not automatically removed from attribution just because a teammate participates in the conversation. We look at who commercially drove the sale before the customer purchased.
+
+### Human Support Does Not Automatically Remove Attribution
+
+If a teammate answers a support question, confirms availability, helps with sizing, or gives general assistance, the sale can still be attributed to Hellotext when the commercial path was driven by Hellotext.
+
+For example, Hellotext may recommend products, the customer may ask whether a size is available, and a teammate may reply that the size is in stock. If the customer then purchases from the product recommendation, the sale may still be attributed because the teammate helped with support but did not take over the commercial sale.
+
+### Human Sales Actions Can Remove Attribution
+
+If a teammate performs a commercial action before the purchase, that can make the sale human‑driven instead of Hellotext‑driven. Human commercial actions include:
+
+* sending a coupon,
+* recommending products,
+* sharing a product link,
+* sharing a checkout link,
+* manually recording a sale.
+
+For example, if Hellotext recommends a product and a teammate later sends a different product link or a coupon, the sale may not be attributed to Hellotext because the teammate became the commercial driver.
+
+### The Latest Commercial Action Matters
+
+When both Hellotext and a teammate perform sales actions, we look at the order of those actions before the purchase.
+
+Hellotext may keep attribution when a teammate answers a question, Hellotext later sends a product recommendation or checkout link, and the customer purchases after Hellotext’s action.
+
+Attribution may be removed when Hellotext sends a product recommendation, a teammate later sends a coupon or checkout link, and the customer purchases after the teammate’s action.
+
+### Human Takeover and Escalated Conversations
+
+Sometimes a teammate may take over the sale even without sending a coupon or product link. If the conversation shows a sustained human‑led exchange immediately before the purchase, the sale may be considered human‑driven.
+
+If Hellotext explicitly hands off the conversation to a human and the sale happens after that handoff, the sale may also be treated as human‑owned rather than Hellotext‑attributed. This helps ensure Hellotext is credited only when it was still driving the sale.
+
+## How We Explain Attribution Decisions
+
+For each sale we review for attribution, we aim to show the evidence behind the decision, such as:
+
+* the campaign, journey, or AI playbook that received credit,
+* the message or event that originated the attribution,
+* whether a teammate participated,
+* whether the teammate’s participation changed attribution,
+* the AI and human sales actions considered before purchase.
+
+When needed, Hellotext may use AI to generate a plain‑language explanation from the underlying attribution evidence. The explanation should summarize the facts, not invent new ones.
+
+Example explanations include:
+
+* Sale was attributed because Hellotext recommended products before purchase and no human sales action was found.
+* Human participated, but only answered a support question. The commercial action came from Hellotext.
+* Human replied after the purchase, so the reply did not affect attribution.
+* Sale was not attributed to Hellotext because a teammate sent a coupon before the purchase.
+* Sale was not attributed to Hellotext because the conversation was escalated to a human before the purchase.
+
 ### Summary
 
 Hellotext assigns revenue only to the channels that use our solution, ensuring your pricing model aligns with actual performance. If you have any questions about a specific case, feel free to contact us. We’re here to help you grow!

--- a/_i18n/es/billing/how-we-attribute-sales.md
+++ b/_i18n/es/billing/how-we-attribute-sales.md
@@ -21,6 +21,62 @@ Con este mecanismo te aseguras de que solo las ventas que se originan a partir d
 * **Eventos creados manualmente**: acciones de seguimiento o registro de ventas que configures manualmente fuera de Hellotext.
 * **Órdenes no confirmadas, canceladas o con devoluciones**: solo atribuimos órdenes confirmadas y excluimos devoluciones.
 
+## ¿Qué pasa cuando tu equipo se suma a la conversación?
+
+Una venta no se elimina automáticamente de la atribución solo porque una persona de tu equipo participe en la conversación. Revisamos quién impulsó comercialmente la venta antes de que el cliente comprara.
+
+### El soporte humano no elimina automáticamente la atribución
+
+Si una persona del equipo responde una consulta de soporte, confirma disponibilidad, ayuda con talles o medidas, o brinda asistencia general, la venta puede seguir atribuida a Hellotext cuando el recorrido comercial fue impulsado por Hellotext.
+
+Por ejemplo, Hellotext puede recomendar productos, el cliente puede preguntar si hay un talle disponible y una persona del equipo puede confirmar que está en stock. Si luego el cliente compra desde la recomendación de producto, la venta puede seguir atribuida porque el equipo ayudó con soporte, pero no tomó el control comercial de la venta.
+
+### Las acciones comerciales humanas pueden eliminar la atribución
+
+Si una persona del equipo realiza una acción comercial antes de la compra, la venta puede pasar a considerarse impulsada por una persona en lugar de Hellotext. Las acciones comerciales humanas incluyen:
+
+* enviar un cupón,
+* recomendar productos,
+* compartir un enlace de producto,
+* compartir un enlace de checkout,
+* registrar manualmente una venta.
+
+Por ejemplo, si Hellotext recomienda un producto y luego una persona del equipo envía otro enlace de producto o un cupón, la venta puede no atribuirse a Hellotext porque esa persona pasó a ser quien impulsó comercialmente la compra.
+
+### Importa la última acción comercial
+
+Cuando Hellotext y una persona del equipo realizan acciones comerciales, revisamos el orden de esas acciones antes de la compra.
+
+Hellotext puede mantener la atribución cuando una persona del equipo responde una pregunta, Hellotext luego envía una recomendación de producto o un enlace de checkout, y el cliente compra después de la acción de Hellotext.
+
+La atribución puede eliminarse cuando Hellotext envía una recomendación de producto, una persona del equipo luego envía un cupón o un enlace de checkout, y el cliente compra después de la acción de esa persona.
+
+### Toma de control humana y conversaciones escaladas
+
+A veces una persona del equipo puede tomar control de la venta incluso sin enviar un cupón o un enlace de producto. Si la conversación muestra un intercambio sostenido liderado por una persona justo antes de la compra, la venta puede considerarse impulsada por el equipo.
+
+Si Hellotext deriva explícitamente la conversación a una persona y la venta ocurre después de esa derivación, la venta también puede tratarse como perteneciente al equipo en lugar de atribuida a Hellotext. Esto ayuda a garantizar que Hellotext reciba crédito solo cuando todavía estaba impulsando la venta.
+
+## Cómo explicamos las decisiones de atribución
+
+Para cada venta que revisamos para atribución, buscamos mostrar la evidencia detrás de la decisión, por ejemplo:
+
+* la campaña, ruta o playbook de IA que recibió el crédito,
+* el mensaje o evento que originó la atribución,
+* si participó una persona del equipo,
+* si esa participación cambió la atribución,
+* las acciones comerciales de IA y humanas consideradas antes de la compra.
+
+Cuando sea necesario, Hellotext puede usar IA para generar una explicación en lenguaje simple a partir de la evidencia de atribución. La explicación debe resumir los hechos, no inventar información nueva.
+
+Algunos ejemplos de explicaciones:
+
+* La venta se atribuyó porque Hellotext recomendó productos antes de la compra y no se encontró ninguna acción comercial humana.
+* Participó una persona, pero solo respondió una consulta de soporte. La acción comercial vino de Hellotext.
+* La persona respondió después de la compra, por lo que su respuesta no afectó la atribución.
+* La venta no se atribuyó a Hellotext porque una persona del equipo envió un cupón antes de la compra.
+* La venta no se atribuyó a Hellotext porque la conversación fue derivada a una persona antes de la compra.
+
 ### Resumen
 
 Hellotext solo asigna ingresos a los canales que utilizan nuestra solución, garantizando que tu modelo de tarifas se alinee con el rendimiento real. Si tienes alguna duda sobre un caso específico, no dudes en contactarnos. ¡Estamos aquí para ayudarte a crecer!


### PR DESCRIPTION
## Summary
- Clarify when human support does or does not affect sales attribution.
- Document how the latest commercial action determines attribution.
- Add plain-language attribution explanation examples in English and Spanish.

## Testing
- Not run (not requested)